### PR TITLE
fixed #11 - Uncaught (in promise) ReferenceError: Web3 is not defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lite-server": "^2.3.0",
     "nodemon": "^1.17.3",
     "truffle": "5.0.2",
-    "truffle-contract": "3.0.6"
+    "truffle-contract": "3.0.6",
+    "web3": "^0.20.6"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ App = {
     await App.loadAccount()
     await App.loadContract()
     await App.render()
+    web3.eth.defaultAccount = web3.eth.accounts[0]
   },
 
   // https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8

--- a/src/index.html
+++ b/src/index.html
@@ -79,6 +79,7 @@
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <!-- Include all compiled plugins (below), or include individual files as needed -->
+    <script src="vendor/web3/dist/web3.js"></script>
     <script src="vendor/bootstrap/dist/js/bootstrap.min.js"></script>
     <script src="vendor/truffle-contract/dist/truffle-contract.js"></script>
     <script src="app.js"></script>


### PR DESCRIPTION
This issue is due to the fact that metamask no longer injects web3 by default

set default account to use on web3
this resolves the following issue:
  Uncaught (in promise) Error: invalid address
    at inputAddressFormatter (formatters.js:274)

package.json
- added web3 dependency

src/app.js
- added default account

src/index.html
- added web3 dependency